### PR TITLE
fix missing endif in receipes.adoc

### DIFF
--- a/recipes.adoc
+++ b/recipes.adoc
@@ -62,6 +62,7 @@ ifdef::env-github[]
 endif::[]
 ifndef::env-github[]
 include::recipes/main/dutch_oven_chicken.adoc[]
+endif::[]
 
 ifdef::env-github[]
 <<recipes/main/honey_walnut_shrimp.adoc#, Honey Walnut Shrimp (Hong Kong Style)>>


### PR DESCRIPTION
Somehow, PR#18 dropped en endif from recipes.adoc.

Signed-off-by: Mike Latimer <mlatimer@suse.com>