### PR TITLE
Add gitpod configuration

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,20 @@
+---
+vscode:
+  extensions:
+    - asciidoctor.asciidoctor-vscode
+tasks:
+  - name: Build the project
+    before: bundle install
+    command: bundle exec ./docbuild.sh
+  - name: Serve the recipebook
+    before: |
+      bundle install
+      bundle exec ./docbuild.sh
+    command: python3 -m http.server -d build
+ports:
+  - port: 8000
+    onOpen: open-browser
+github:
+  prebuilds:
+    addCheck: true
+    addComment: true

--- a/README.adoc
+++ b/README.adoc
@@ -6,6 +6,10 @@ https://suse.github.io/recipebook/recipes.html
 * Clone the repo and open recipes.adoc locally in a browser that supports
   AsciiDoc or in another tool such as asciidoctor
 
+* Open this project in
+  https://gitpod.io/#https://github.com/SUSE/recipebook[gitpod] and edit it
+  directly there.
+
 * The GitHub preview of the in-development recipes is at
 <<recipes.adoc#>>.
 


### PR DESCRIPTION
This PR adds a basic configuration for editing this project with gitpod. Once it is merged, you'll be able to to edit it via the supplied url. At the moment you can give it a try via https://gitpod.io/#https://github.com/dcermak/recipebook

The configuration includes a basic setup of the webeditor to include asciidoc support, a run of the build job and a dev server so that the contributor can see their rendered html without leaving their browser.